### PR TITLE
Liquidity adding handler fix

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -3,7 +3,7 @@ description: ''
 repository: ''
 schema: ./schema.graphql
 network:
-  endpoint: wss://ws.framenode-3.s3.dev.sora2.soramitsu.co.jp
+  endpoint: wss://ws.stage.sora2.soramitsu.co.jp
   types: {
     "AccountInfo": "AccountInfoWithDualRefCount",
     "Address": "AccountId",
@@ -557,7 +557,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 	84112
+    startBlock: 	167836
     mapping:
       handlers:
         

--- a/src/mappings/liquidityDepositHandler.ts
+++ b/src/mappings/liquidityDepositHandler.ts
@@ -1,33 +1,46 @@
-import {SubstrateExtrinsic, SubstrateEvent} from '@subql/types';
-import {formatU128ToBalance, assignCommonHistoryElemInfo} from "./utils";
+import { SubstrateExtrinsic, SubstrateEvent } from '@subql/types';
+import { formatU128ToBalance, assignCommonHistoryElemInfo } from "./utils";
 
 export async function handleLiquidityDeposit(extrinsic: SubstrateExtrinsic): Promise<void> {
-    
+
     logger.debug("Caught liquidity adding extrinsic")
-    
+
     const record = assignCommonHistoryElemInfo(extrinsic)
 
     if (record.success) {
-        
-        let inputCurrencyTransferEvent = extrinsic.events.find( e  => e.event.method === 'Transferred' && e.event.section === 'currencies')
-        const {event: {data: [inputAsset, , , inputTransferedAmount]}} = inputCurrencyTransferEvent;
 
-        let outputCurrencyTransferEvent = extrinsic.events.find(e => (e as SubstrateEvent).idx === (inputCurrencyTransferEvent as SubstrateEvent).idx + 1)
-        const {event: {data: [outputAsset, , , outputTransferedAmount]}} = outputCurrencyTransferEvent;
-            
-        record.liquidityOperation = {
-            type: "Deposit",
-            baseAssetId: inputAsset.toString(),
-            targetAssetId: outputAsset.toString(),
-            baseAssetAmount: formatU128ToBalance(inputTransferedAmount.toString()),
-            targetAssetAmount: formatU128ToBalance(outputTransferedAmount.toString())
+        let feeWithdrawalevent = extrinsic.events.find(e => e.event.method === 'FeeWithdrawn')
+
+        let feeWithdrawaleventIndex = (feeWithdrawalevent as SubstrateEvent).idx
+
+        let inputCurrencyTransferEvent = extrinsic.events.slice(0, feeWithdrawaleventIndex).find(e => e.event.method === 'Transferred' && e.event.section === 'currencies')
+
+        if (inputCurrencyTransferEvent) {
+
+            const { event: { data: [inputAsset, , , inputTransferedAmount] } } = inputCurrencyTransferEvent;
+
+            let outputCurrencyTransferEvent = extrinsic.events.find(e => (e as SubstrateEvent).idx === (inputCurrencyTransferEvent as SubstrateEvent).idx + 1)
+            const { event: { data: [outputAsset, , , outputTransferedAmount] } } = outputCurrencyTransferEvent;
+
+            record.liquidityOperation = {
+                type: "Deposit",
+                baseAssetId: inputAsset.toString(),
+                targetAssetId: outputAsset.toString(),
+                baseAssetAmount: formatU128ToBalance(inputTransferedAmount.toString()),
+                targetAssetAmount: formatU128ToBalance(outputTransferedAmount.toString())
+            }
 
         }
-    } 
-    
+
+        else {
+            return
+        }
+
+    }
+
     else {
-        
-        const {extrinsic: {args: [, assetAId, assetBId, assetADesired, assetBDesired]}} = extrinsic;
+
+        const { extrinsic: { args: [, assetAId, assetBId, assetADesired, assetBDesired] } } = extrinsic;
 
         record.liquidityOperation = {
             type: "Deposit",
@@ -36,11 +49,12 @@ export async function handleLiquidityDeposit(extrinsic: SubstrateExtrinsic): Pro
             baseAssetAmount: formatU128ToBalance(assetADesired.toString()),
             targetAssetAmount: formatU128ToBalance(assetBDesired.toString())
         }
+
     }
-    
+
     await record.save();
 
     logger.debug(`===== Saved liquidity deposit with ${extrinsic.extrinsic.hash.toString()} txid =====`);
-    
+
 }
 


### PR DESCRIPTION
The events of liquidity addings are now being checked for the presence before the network fee is withdrawn. That way the program ensures that the liquidity deposit extrinsic has the valid events.