### PR TITLE
Rolled back Timepoint type

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -48,10 +48,7 @@ network:
       "height": "MultiChainHeight",
       "index": "u32"
     },
-    "Timepoint": {
-      "height": "BlockNumber",
-      "index": "Index"
-    },
+    "Timepoint": "BridgeTimepoint", #todo use a separate timepoint for MST accounts
     "ChangePeersContract": {
       "_enum": [
           "XOR",
@@ -581,7 +578,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 0
+    startBlock: 70500
     mapping:
       handlers:
 

--- a/project.yaml
+++ b/project.yaml
@@ -578,7 +578,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 70500
+    startBlock: 0
     mapping:
       handlers:
 


### PR DESCRIPTION
We have `BridgeTimepoint` and `Timpoint` for mst accounts. We can't differentiate them in metadata now, that's why it has to be rolled back.