### PR TITLE
onfinality/subql-node to v0.27.3-5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_PASSWORD: postgres
 
   subquery-node:
-    image: onfinality/subql-node:latest
+    image: onfinality/subql-node:v0.27.3-5
     depends_on:
       - postgres
     restart: always
@@ -25,7 +25,6 @@ services:
       - ./:/app
     command:
       - -f=/app
-      # - --local
       - --log-level=debug
 
   graphql-engine:


### PR DESCRIPTION
Graphql is not starting with the node v0.28.0 operating on project spec v0.0.1